### PR TITLE
Optimise emit all command start

### DIFF
--- a/src/Console/Commands/EmitAllEvents.php
+++ b/src/Console/Commands/EmitAllEvents.php
@@ -35,7 +35,7 @@ class EmitAllEvents extends Command
         $queueConnection    = $this->argument('queueConnection');
         $databaseConnection = $this->option('unbufferedConnection');
         $batchSize          = $this->option('batchSize');
-        $totalEventsToEmit  = DomainEvent::count();
+        $totalEventsToEmit  = DomainEvent::max('id');
         $bar                = $this->output->createProgressBar($totalEventsToEmit);
 
         $bar->start();


### PR DESCRIPTION
Optimise bar progress in emit all command to speed up the start in large events table