### PR TITLE
Do not inject logger in AmqpMiddleware

### DIFF
--- a/src/EventStoreMiddlewares/AmqpMiddleware.php
+++ b/src/EventStoreMiddlewares/AmqpMiddleware.php
@@ -3,7 +3,7 @@
 namespace Softonic\TransactionalEventPublisher\EventStoreMiddlewares;
 
 use Exception;
-use Psr\Log\LoggerInterface;
+use Illuminate\Support\Facades\Log;
 use Softonic\Amqp\Amqp;
 use Softonic\TransactionalEventPublisher\Contracts\EventMessageContract;
 use Softonic\TransactionalEventPublisher\Contracts\EventStoreMiddlewareContract;
@@ -23,28 +23,20 @@ class AmqpMiddleware implements EventStoreMiddlewareContract
     private $properties;
 
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * AmqpMiddleware constructor.
      *
      * @param AmqpMessageFactory $messageFactory
      * @param Amqp               $amqp
      * @param array              $properties
-     * @param LoggerInterface    $logger
      */
     public function __construct(
         AmqpMessageFactory $messageFactory,
         Amqp $amqp,
-        array $properties,
-        LoggerInterface $logger
+        array $properties
     ) {
         $this->messageFactory = $messageFactory;
         $this->amqp           = $amqp;
         $this->properties     = $properties;
-        $this->logger         = $logger;
     }
 
     /**
@@ -78,7 +70,7 @@ class AmqpMiddleware implements EventStoreMiddlewareContract
 
             return true;
         } catch (Exception $e) {
-            $this->logger->error($e->getMessage());
+            Log::error($e->getMessage());
 
             return false;
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Softonic\TransactionalEventPublisher;
 
 use Illuminate\Contracts\Bus\Dispatcher;
-use Illuminate\Log\Logger;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 use Softonic\Amqp\Amqp;
 use Softonic\TransactionalEventPublisher\Console\Commands\EmitAllEvents;
@@ -64,8 +63,7 @@ class ServiceProvider extends LaravelServiceProvider
             return new AmqpMiddleware(
                 new AmqpMessageFactory(),
                 new Amqp(),
-                config('transactional-event-publisher.properties.amqp'),
-                resolve(Logger::class)
+                config('transactional-event-publisher.properties.amqp')
             );
         });
 

--- a/tests/EventStoreMiddlewares/AmqpMiddlewareTest.php
+++ b/tests/EventStoreMiddlewares/AmqpMiddlewareTest.php
@@ -2,9 +2,9 @@
 
 namespace Softonic\TransactionalEventPublisher\Tests\EventStoreMiddlewares;
 
+use Illuminate\Support\Facades\Log;
 use Mockery;
 use PhpAmqpLib\Message\AMQPMessage;
-use Psr\Log\LoggerInterface;
 use Softonic\Amqp\Amqp;
 use Softonic\TransactionalEventPublisher\Contracts\EventMessageContract;
 use Softonic\TransactionalEventPublisher\EventStoreMiddlewares\AmqpMiddleware;
@@ -19,8 +19,7 @@ class AmqpMiddlewareTest extends TestCase
         $amqpMessage = new AMQPMessage();
         $properties  = ['AMQP properties'];
 
-        $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('error')
+        Log::shouldReceive('error')
             ->once();
 
         $amqpMessageFactory = Mockery::mock(AmqpMessageFactory::class);
@@ -35,12 +34,7 @@ class AmqpMiddlewareTest extends TestCase
             ->once()
             ->andThrow('\Exception');
 
-        $amqpMiddleware = new AmqpMiddleware(
-            $amqpMessageFactory,
-            $amqpMock,
-            $properties,
-            $logger
-        );
+        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties);
 
         self::assertFalse($amqpMiddleware->store($message));
     }
@@ -65,8 +59,7 @@ class AmqpMiddlewareTest extends TestCase
         $amqpMessage = new AMQPMessage();
         $properties  = ['AMQP properties'];
 
-        $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('error')
+        Log::shouldReceive('error')
             ->once();
 
         $amqpMessageFactory = Mockery::mock(AmqpMessageFactory::class);
@@ -84,12 +77,7 @@ class AmqpMiddlewareTest extends TestCase
             ->once()
             ->andThrow('\Exception');
 
-        $amqpMiddleware = new AmqpMiddleware(
-            $amqpMessageFactory,
-            $amqpMock,
-            $properties,
-            $logger
-        );
+        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties);
 
         self::assertFalse($amqpMiddleware->store(...$messages));
     }
@@ -114,7 +102,6 @@ class AmqpMiddlewareTest extends TestCase
     {
         $message     = $this->getOneMessage();
         $properties  = ['AMQP properties'];
-        $logger      = Mockery::mock(LoggerInterface::class);
         $amqpMessage = new AMQPMessage();
 
         $amqpMock = Mockery::mock(Amqp::class);
@@ -129,7 +116,7 @@ class AmqpMiddlewareTest extends TestCase
             ->once()
             ->andReturn($amqpMessage);
 
-        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties, $logger);
+        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties);
 
         self::assertTrue($amqpMiddleware->store($message));
     }
@@ -138,7 +125,6 @@ class AmqpMiddlewareTest extends TestCase
     {
         $messages          = $this->getTwoMessages();
         $properties        = ['AMQP properties'];
-        $logger            = Mockery::mock(LoggerInterface::class);
         $firstAmqpMessage  = new AMQPMessage();
         $secondAmqpMessage = new AMQPMessage();
 
@@ -162,7 +148,7 @@ class AmqpMiddlewareTest extends TestCase
             ->twice()
             ->andReturn($firstAmqpMessage, $secondAmqpMessage);
 
-        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties, $logger);
+        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties);
 
         self::assertTrue($amqpMiddleware->store(...$messages));
     }
@@ -173,7 +159,6 @@ class AmqpMiddlewareTest extends TestCase
         $properties         = [
             'routing_key_fields' => ['site', 'service', 'eventType', 'modelName'],
         ];
-        $logger             = Mockery::mock(LoggerInterface::class);
         $message->site      = 'softonic';
         $message->service   = 'service';
         $message->eventType = 'created';
@@ -192,7 +177,7 @@ class AmqpMiddlewareTest extends TestCase
             ->once()
             ->andReturn($amqpMessage);
 
-        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties, $logger);
+        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties);
 
         self::assertTrue($amqpMiddleware->store($message));
     }
@@ -203,7 +188,6 @@ class AmqpMiddlewareTest extends TestCase
         $properties        = [
             'routing_key_fields' => ['site', 'service', 'eventType', 'modelName'],
         ];
-        $logger            = Mockery::mock(LoggerInterface::class);
         $firstAmqpMessage  = new AMQPMessage();
         $secondAmqpMessage = new AMQPMessage();
 
@@ -227,7 +211,7 @@ class AmqpMiddlewareTest extends TestCase
             ->twice()
             ->andReturn($firstAmqpMessage, $secondAmqpMessage);
 
-        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties, $logger);
+        $amqpMiddleware = new AmqpMiddleware($amqpMessageFactory, $amqpMock, $properties);
 
         self::assertTrue($amqpMiddleware->store(...$messages));
     }


### PR DESCRIPTION
There's a problem when injecting the Illuminate\Log\Logger to the AmqpMiddleware, that now is injected to AsyncMiddleware and serialized when dispatching the SendDomainEventsJob:
`Serialization of ‘Closure’ is not allowed`
To solve this, we're using Illuminate\Support\Facades\Log directly in AmqpMiddleware so no need to inject the other one.