### PR TITLE
Added logging of the progress

### DIFF
--- a/src/Console/Commands/EmitEvents.php
+++ b/src/Console/Commands/EmitEvents.php
@@ -56,8 +56,8 @@ class EmitEvents extends Command
         $this->eventPublisherMiddleware = $eventPublisherMiddleware;
 
         $this->databaseConnection = $this->option('dbConnection');
-        $this->batchSize          = (int)$this->option('batchSize');
-        $resetCursor              = $this->option('allEvents');
+        $this->batchSize = (int)$this->option('batchSize');
+        $resetCursor = $this->option('allEvents');
 
         $this->cursor = $this->getInitialCursor($resetCursor);
 
@@ -92,7 +92,7 @@ class EmitEvents extends Command
     public function sendBatch(): void
     {
         $this->eventsProcessed = false;
-        $lastId                = $this->cursor->last_id;
+        $lastId = $this->cursor->last_id;
 
         try {
             $events = DomainEvent::on($this->databaseConnection)->where('id', '>', $lastId)->cursor();
@@ -127,10 +127,7 @@ class EmitEvents extends Command
             throw new RuntimeException($errorMessage);
         }
 
-        $lastId             = $events->last()->id;
-        $eventMessagesCount = count($eventMessages);
-
-        Log::info("Published {$eventMessagesCount} events, last event ID published: {$lastId}");
+        $lastId = $events->last()->id;
 
         try {
             $this->cursor->update(['last_id' => $lastId]);
@@ -140,7 +137,11 @@ class EmitEvents extends Command
             throw $e;
         }
 
-        $this->eventsProcessed  = true;
+        $eventMessagesCount = count($eventMessages);
+
+        Log::info("Published {$eventMessagesCount} events, last event ID published: {$lastId}");
+
+        $this->eventsProcessed = true;
         $this->attemptForErrors = $this->attemptForNoEvents = 1;
     }
 

--- a/src/Console/Commands/EmitEvents.php
+++ b/src/Console/Commands/EmitEvents.php
@@ -56,8 +56,8 @@ class EmitEvents extends Command
         $this->eventPublisherMiddleware = $eventPublisherMiddleware;
 
         $this->databaseConnection = $this->option('dbConnection');
-        $this->batchSize = (int)$this->option('batchSize');
-        $resetCursor = $this->option('allEvents');
+        $this->batchSize          = (int)$this->option('batchSize');
+        $resetCursor              = $this->option('allEvents');
 
         $this->cursor = $this->getInitialCursor($resetCursor);
 
@@ -92,7 +92,7 @@ class EmitEvents extends Command
     public function sendBatch(): void
     {
         $this->eventsProcessed = false;
-        $lastId = $this->cursor->last_id;
+        $lastId                = $this->cursor->last_id;
 
         try {
             $events = DomainEvent::on($this->databaseConnection)->where('id', '>', $lastId)->cursor();
@@ -127,15 +127,20 @@ class EmitEvents extends Command
             throw new RuntimeException($errorMessage);
         }
 
+        $lastId             = $events->last()->id;
+        $eventMessagesCount = count($eventMessages);
+
+        Log::info("Published {$eventMessagesCount} events, last event ID published: {$lastId}");
+
         try {
-            $this->cursor->update(['last_id' => $events->last()->id]);
+            $this->cursor->update(['last_id' => $lastId]);
         } catch (Exception $e) {
             $this->cursor->discardChanges();
 
             throw $e;
         }
 
-        $this->eventsProcessed = true;
+        $this->eventsProcessed  = true;
         $this->attemptForErrors = $this->attemptForNoEvents = 1;
     }
 


### PR DESCRIPTION
Example of the log:
```
[2023-07-06T16:08:32.354940+00:00] local.INFO: Published 100 events, last event ID published: 100 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:08:32.430117+00:00] local.INFO: Published 100 events, last event ID published: 200 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:08:32.433326+00:00] local.INFO: Published 11 events, last event ID published: 211 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:11.732856+00:00] local.INFO: Published 5 events, last event ID published: 216 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:21.862934+00:00] local.INFO: Published 100 events, last event ID published: 316 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:21.870924+00:00] local.INFO: Published 100 events, last event ID published: 416 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:21.878136+00:00] local.INFO: Published 82 events, last event ID published: 498 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:21.881544+00:00] local.INFO: Published 9 events, last event ID published: 507 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:21.884144+00:00] local.INFO: Published 1 events, last event ID published: 508 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:21.887225+00:00] local.INFO: Published 1 events, last event ID published: 509 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
[2023-07-06T16:09:21.891617+00:00] local.INFO: Published 1 events, last event ID published: 510 [] {"x-request-id":"4dcb4ca7-714b-4244-91d5-dcecf28853e1","x-msg-priority":999}
...
```